### PR TITLE
dockerfile working on raspberry pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM hypriot/rpi-node
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+RUN npm install
+
+# Bundle app source
+COPY . /usr/src/app
+RUN cp .envnow .env
+
+RUN npm run clean
+RUN npm run build
+
+EXPOSE 8004
+CMD [ "npm", "start" ]


### PR DESCRIPTION
First of all thanks for this awesome project, it is so easy to deploy to now.

So I fiddle a little and got it running on a docker container on a raspberry pi with this:
`docker run -p 80:8004 --restart='always' --name react-universally-d react-universally`

Only catch is that it is based on `.envnow` because `.env` is ignored by git.