### PR TITLE
rest operator not working 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",
     "babel-plugin-transform-class-properties": "6.11.5",
+    "babel-plugin-transform-es2015-destructuring": "^6.9.0",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-preset-es2015": "6.13.2",
     "babel-preset-react": "6.11.1",

--- a/src/server/htmlPage/render.js
+++ b/src/server/htmlPage/render.js
@@ -40,7 +40,7 @@ const scripts = scriptTags(clientAssets.scripts);
 function render(rootReactElement : ?$React$Element, initialState : ?Object) {
   const reactRenderString = rootReactElement
     ? renderToString(rootReactElement)
-    : null;
+    : '';
 
   const helmet = rootReactElement
     // We run 'react-helmet' after our renderToString call so that we can fish
@@ -50,7 +50,7 @@ function render(rootReactElement : ?$React$Element, initialState : ?Object) {
     // @see https://github.com/nfl/react-helmet
     ? Helmet.rewind()
     // There was no react element, so we just us an empty helmet.
-    : null;
+    : ''n;
 
   return `<!DOCTYPE html>
     <html ${helmet ? helmet.htmlAttributes.toString() : ''}>

--- a/tools/webpack/configFactory.js
+++ b/tools/webpack/configFactory.js
@@ -265,6 +265,7 @@ function webpackConfigFactory({ target, mode }, { json }) {
           query: merge(
             {
               plugins: [
+                'transform-es2015-destructuring',
                 'transform-object-rest-spread',
                 'transform-class-properties',
               ],


### PR DESCRIPTION
Rest operator was not working, even if we have node 6, since `babel-plugin-transform-es2015-destructuring` plugin is needed. 

See here for more info: https://babeljs.io/docs/plugins/transform-object-rest-spread/
```
Even if you are using Node 6 or a platform that supports destructuring, transform-es2015-destructuring will currently need to be enabled if using object rest properties.
```
