### PR TITLE
vendor code splitting

### DIFF
--- a/tools/webpack/configFactory.js
+++ b/tools/webpack/configFactory.js
@@ -122,9 +122,16 @@ function webpackConfigFactory({ target, mode }, { json }) {
           ifDevClient('react-hot-loader/patch'),
           ifDevClient(`webpack-hot-middleware/client?reload=true&path=http://localhost:${process.env.CLIENT_DEVSERVER_PORT}/__webpack_hmr`),
           path.resolve(appRootPath, `./src/${target}/index.js`),
-        ]),
-        vendor
-      }
+        ])
+      },
+      ifProdClient({
+        vendor: [
+          'react',
+          'react-router',
+          'react-dom',
+          'react-helmet'
+        ]
+      })
     ),
     output: {
       // The dir in which our bundle should be output.
@@ -175,10 +182,12 @@ function webpackConfigFactory({ target, mode }, { json }) {
       // cases where browsers end up having to download all the client chunks
       // even though 1 or 2 may have only changed.
 
-      new webpack.optimize.CommonsChunkPlugin({
-        names: ['vendor'],
-        minChunks: Infinity
-      }),
+      ifProdClient(
+        new webpack.optimize.CommonsChunkPlugin({
+          names: ['vendor'],
+          minChunks: Infinity
+        })
+      ),
       ifClient(new WebpackMd5Hash()),
 
       // Each key passed into DefinePlugin is an identifier.

--- a/tools/webpack/configFactory.js
+++ b/tools/webpack/configFactory.js
@@ -12,6 +12,13 @@ const { removeEmpty, ifElse, merge } = require('../utils');
 
 const appRootPath = appRoot.toString();
 
+const vendor = [
+  'react',
+  'react-router',
+  'react-dom',
+  'react-helmet'
+];
+
 // @see https://github.com/motdotla/dotenv
 dotenv.config(process.env.NOW
   // This is to support deployment to the "now" host.  See the README for more info.
@@ -116,6 +123,7 @@ function webpackConfigFactory({ target, mode }, { json }) {
           ifDevClient(`webpack-hot-middleware/client?reload=true&path=http://localhost:${process.env.CLIENT_DEVSERVER_PORT}/__webpack_hmr`),
           path.resolve(appRootPath, `./src/${target}/index.js`),
         ]),
+        vendor
       }
     ),
     output: {
@@ -166,6 +174,11 @@ function webpackConfigFactory({ target, mode }, { json }) {
       // our long term browser caching strategy for our client bundle, avoiding
       // cases where browsers end up having to download all the client chunks
       // even though 1 or 2 may have only changed.
+
+      new webpack.optimize.CommonsChunkPlugin({
+        names: ['vendor'],
+        minChunks: Infinity
+      }),
       ifClient(new WebpackMd5Hash()),
 
       // Each key passed into DefinePlugin is an identifier.


### PR DESCRIPTION
I think it would be great to put common libraries for each route such as react, react-dom, react, immutable etc in common chunk like vendor.js.  
But there is one trouble `npm run start` doesn't start app anymore.
`npm run development` and `npm run build` works well though.