### PR TITLE
update extract text plugin for V. 2

### DIFF
--- a/tools/webpack/configFactory.js
+++ b/tools/webpack/configFactory.js
@@ -376,7 +376,7 @@ function webpackConfigFactory({ target, mode }, { json }) {
           // registered within the plugins section too.
           ifProdClient({
             loader: ExtractTextPlugin.extract({
-              notExtractLoader: 'style-loader',
+              fallbackLoader: 'style-loader',
               loader: 'css-loader',
             }),
           }),


### PR DESCRIPTION
In extract text plugin version 2, `notExtractLoader` has been changed into `fallbackLoader`. See https://github.com/webpack/extract-text-webpack-plugin.