### PR TITLE
Add to gitignore and eslintignore files.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 tools/flow/
+node_modules/
+build/

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
     "defaultParams": true
   },
   "rules": {
-    # We use the 'import' plugin which allows for cases "flow" awareness.
+    // We use the 'import' plugin which allows for cases "flow" awareness.
     "no-duplicate-imports": 0,
 
     "flow-vars/define-flow-type": 1,

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ npm-debug.log
 
 # IntelliJ IDE ignore
 .idea
+
+# Visual Studio Code
+.vscode


### PR DESCRIPTION
Very minor stuff - eslint complains about the # in its config, and the addition to .eslintignore allows running .eslint in the base directory.

I added this to `eslint --fix .` the base directory to convert line endings, since they're CRLF in the repo, which causes a massive number of eslint failures. I can fix the line endings once in a separate pull request, but I need to understand the git settings a bit more first...