### PR TITLE
Introduces a serverless option for production clients hosted without a server on a CDN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This starter kit contains all the build tooling and configuration you need to ki
 ## Features
 
   - 🌍 Server side rendering.
+  - 🌍 Serverless option - builds a production client that does not need a server (to be hosted on a CDN).
   - 🔥 Extreme live development - hot reloading of client/server source as, with high level of error tolerance.
   - 🚄 `express` server.
   - 👮 Security on the `express` server using `helmet` and `hpp`.
@@ -169,6 +170,11 @@ Builds the client and server bundles, with the output being production optimized
 ### `npm run start`
 
 Executes the server.  It expects you to have already built the bundles either via the `npm run build` command or manually.
+
+### `npm run build:serverless`
+
+Builds the serverless client bundle, with the output being production optimized.
+This can be hosted on a CDN without the need for server-side rendering.
 
 ### `npm run clean`
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rimraf build",
     "development": "node ./tools/development",
     "build": "npm run clean && webpack --config ./tools/webpack/client.config.js && webpack --config ./tools/webpack/universalMiddleware.config.js && webpack --config ./tools/webpack/server.config.js",
+    "build:serverless": "npm run clean && webpack --config ./tools/webpack/client.config.js --env.serverless",
     "start": "node build/server"
   },
   "repository": {
@@ -59,6 +60,7 @@
     "babel-preset-react": "6.16.0",
     "chokidar": "1.6.0",
     "colors": "1.1.2",
+    "copy-webpack-plugin": "^3.0.1",
     "css-loader": "0.25.0",
     "dotenv": "2.0.0",
     "eslint": "3.6.1",
@@ -70,6 +72,7 @@
     "extract-text-webpack-plugin": "2.0.0-beta.4",
     "file-loader": "0.9.0",
     "flow-bin": "0.32.0",
+    "html-webpack-plugin": "^2.22.0",
     "json-loader": "0.5.4",
     "node-notifier": "4.6.1",
     "regenerator-runtime": "0.9.5",

--- a/src/client/index.ejs
+++ b/src/client/index.ejs
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charSet='utf-8'/>
+  <meta httpEquiv='X-UA-Compatible' content='IE=edge'/>
+  <meta httpEquiv='Content-Language' content='en'/>
+  <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico'/>
+  <base href="<%= htmlWebpackPlugin.options.baseurl %>">
+  <% for (var css in htmlWebpackPlugin.files.css) { %>
+  <link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+  <% } %>
+  <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+</head>
+<body>
+<div id="app"></div>
+<script type='text/javascript'>
+  // [Optional] The initial state for the redux store which will be used by the
+  // client to mount the redux store into the desired state.
+  window.APP_STATE = {};
+</script>
+<% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+<script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+<% } %>
+</body>
+</html>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,7 +4,8 @@ import React from 'react';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import Router from 'react-router/lib/Router';
-import browserHistory from 'react-router/lib/browserHistory';
+import useRouterHistory from 'react-router/lib/useRouterHistory';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
 import match from 'react-router/lib/match';
 import routes from '../shared/universal/routes';
 
@@ -17,6 +18,8 @@ function routerError(error) {
 }
 
 function renderApp(appRoutes) {
+  // Create the routing history.
+  let browserHistory = useRouterHistory(createBrowserHistory)({basename: process.env.SERVERLESS ? process.env.CLIENT_BUNDLE_HTTP_PATH : ''});
   // As we are using dynamic react-router routes we have to use the following
   // asynchronous routing mechanism supported by the `match` function.
   // @see https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md


### PR DESCRIPTION
With this small change we are now able to also create a production client that can be hosted on a CDN without the need for a server and server-side rendering.
There are no code changes needed - only run `npm run build:serverless` to build the serverless production client output from exactly the same code as the server-side rendered code.
I think this is a very valuable, none-intrusive additional feature and would love to see it being merged into `react-universally`.
Cheers
Bernd
