### PR TITLE
WIP: async/await DEV server launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "clean": "node tools/scripts/clean",
-    "development": "node tools/development",
+    "development:await": "babel-node --presets='latest' ./tools/development",
+    "development": "node ./tools/development",
     "build": "node tools/scripts/build",
     "analyze": "node tools/scripts/analyze",
     "start": "node build/server",
@@ -40,11 +41,13 @@
   "homepage": "https://github.com/ctrlplusb/react-universally#readme",
   "dependencies": {
     "app-root-path": "2.0.1",
+    "bluebird": "^3.4.6",
     "code-split-component": "1.0.1",
     "compression": "1.6.2",
     "express": "4.14.0",
     "helmet": "3.0.0",
     "hpp": "0.2.1",
+    "memory-fs": "^0.3.0",
     "node-uuid": "1.4.7",
     "normalize.css": "5.0.0",
     "path": "0.12.7",
@@ -53,7 +56,8 @@
     "react-helmet": "3.1.0",
     "react-router": "4.0.0-alpha.5",
     "serialize-javascript": "1.3.0",
-    "source-map-support": "0.4.6"
+    "source-map-support": "0.4.6",
+    "thenify": "^3.2.1"
   },
   "devDependencies": {
     "assets-webpack-plugin": "3.5.0",

--- a/tools/development/index-await.js
+++ b/tools/development/index-await.js
@@ -1,0 +1,78 @@
+import path, { resolve as pathResolve } from 'path';
+// import chokidar from 'chokidar';
+// import Promise from 'bluebird';
+import webpack from 'webpack';
+import { createNotification, compilerIsDone, expressCreateServer } from '../utils';
+// import HotServer from './hotServer';
+// import HotClient from './hotClient';
+// import ensureVendorDLLExists from './ensureVendorDLLExists';
+import vendorDLLPaths from '../config/vendorDLLPaths';
+import envVars from '../config/envVars';
+
+// Create CLIENT compiler configuration
+const clientConfigFactory = require('../webpack/client.config');
+const clientConfig = clientConfigFactory({ mode: 'development' });
+// Install the vendor DLL plugin.
+/*
+clientConfig.plugins.push(
+  new webpack.DllReferencePlugin({
+    manifest: require(vendorDLLPaths.dllJsonPath),
+  })
+);
+*/
+
+// Create MIDDLEWARE compiler configuration
+const middlewareConfigFactory = require('../webpack/universalMiddleware.config');
+const middlewareConfig = middlewareConfigFactory({ mode: 'development' });
+
+// Create SERVER compiler configuration
+const serverConfigFactory = require('../webpack/server.config');
+const serverConfig = serverConfigFactory({ mode: 'development' });
+
+// Main functionality
+// await Promise.all should allow us to run the functions in parallel
+(async () => {
+  const {
+    compilers: [
+      clientCompiler,
+      middlewareCompiler,
+      serverCompiler
+    ]
+  } = await webpack([clientConfig, middlewareConfig, serverConfig]);
+
+  /* WHY IS THIS NOT WORKING ?!
+   await Promise.all([
+   compilerIsDone(clientCompiler).then(expressCreateServer(clientCompiler, envVars.CLIENT_DEVSERVER_PORT)),
+   compilerIsDone(middlewareCompiler),
+   compilerIsDone(serverCompiler)
+   ]);
+   */
+  await compilerIsDone(clientCompiler).then(expressCreateServer(clientCompiler, envVars.CLIENT_DEVSERVER_PORT));
+  await compilerIsDone(middlewareCompiler);
+  await compilerIsDone(serverCompiler);
+
+  // starts the server
+  try {
+    const compiledOutputPath = path.resolve(
+      serverCompiler.options.output.path, `${Object.keys(serverCompiler.options.entry)[0]}.js`
+    );
+    // The server bundle  will automatically start the web server just by
+    // requiring it. It returns the http listener too.
+    const listener = require(compiledOutputPath).default;
+    const url = `http://localhost:${envVars.SERVER_PORT}`;
+
+    createNotification({
+      title: 'server',
+      level: 'info',
+      message: `Running on ${url} with latest changes.`,
+      open: url
+    });
+  } catch (err) {
+    createNotification({
+      title: 'server',
+      level: 'error',
+      message: 'Failed to start, please check the console for more information.',
+    });
+    console.log(err);
+  }
+})();

--- a/tools/webpack/configFactory.js
+++ b/tools/webpack/configFactory.js
@@ -78,6 +78,7 @@ function webpackConfigFactory({ target, mode }, { json }) {
   const ifProdClient = ifElse(isProd && isClient);
 
   return {
+    name: target,
     // We need to state that we are targetting "node" for our server bundle.
     target: ifNodeTarget('node', 'web'),
     // We have to set this to be able to use these items when executing a


### PR DESCRIPTION
POC for launching the dev server using `async/await` operations instead of relying on the `listenerManager`. Make code cleaner and easier to understand, in my opinion.

In order to check it, first you need to launch as usual:
`npm run development`
You can then stop the server, and launch the other variant:
`npm run development:await`.

There are some issues to be fixed:
- generating vendor dlls is not yet implemented
- `await Promise.all` does not seem to work as expected, really annoying. Any ideas how to remove all those `await` lines and simply rely on parallel execution using `Promise.all`? Theoretically, it should just work.
- new logger to be added (I intend to remove `colors` and use `chalk` instead).
- also, the watching process needs to be refined.
