### PR TITLE
Bug/apollo render typo fix

### DIFF
--- a/src/shared/universal/components/App/About/index.js
+++ b/src/shared/universal/components/App/About/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import About from './About';
-
-export default About;
+export { default } from './About';

--- a/src/shared/universal/components/App/Error404/index.js
+++ b/src/shared/universal/components/App/Error404/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Error404 from './Error404';
-
-export default Error404;
+export { default } from './Error404';

--- a/src/shared/universal/components/App/Foo/index.js
+++ b/src/shared/universal/components/App/Foo/index.js
@@ -1,3 +1,3 @@
-import Foo from './Foo';
+/* @flow */
 
-export default Foo;
+export { default } from './Foo';

--- a/src/shared/universal/components/App/Header/Logo/index.js
+++ b/src/shared/universal/components/App/Header/Logo/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Logo from './Logo';
-
-export default Logo;
+export { default } from './Logo';

--- a/src/shared/universal/components/App/Header/Menu/index.js
+++ b/src/shared/universal/components/App/Header/Menu/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Menu from './Menu';
-
-export default Menu;
+export { default } from './Menu';

--- a/src/shared/universal/components/App/Header/index.js
+++ b/src/shared/universal/components/App/Header/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Header from './Header';
-
-export default Header;
+export { default } from './Header';

--- a/src/shared/universal/components/App/Home/index.js
+++ b/src/shared/universal/components/App/Home/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Home from './Home';
-
-export default Home;
+export { default } from './Home';

--- a/src/shared/universal/components/App/Posts/Post/index.js
+++ b/src/shared/universal/components/App/Posts/Post/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Post from './Post';
-
-export default Post;
+export { default } from './Post';

--- a/src/shared/universal/components/App/Posts/index.js
+++ b/src/shared/universal/components/App/Posts/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import Posts from './Posts';
-
-export default Posts;
+export { default } from './Posts';

--- a/src/shared/universal/components/App/index.js
+++ b/src/shared/universal/components/App/index.js
@@ -1,5 +1,3 @@
 /* @flow */
 
-import App from './App';
-
-export default App;
+export { default } from './App';

--- a/src/universalMiddleware/render.js
+++ b/src/universalMiddleware/render.js
@@ -81,7 +81,7 @@ type RenderArgs = {
  * @return The full HTML page in the form of a React element.
  */
 function render(args: RenderArgs) {
-  const { app, initialState, nonce, helmet, codeSplitState } = args;
+  const { markup, initialState, nonce, helmet, codeSplitState } = args;
 
   // The chunks that we need to fetch the assets (js/css) for and then include
   // said assets as script/style tags within our html.
@@ -121,7 +121,7 @@ function render(args: RenderArgs) {
         ${helmet ? helmet.style.toString() : ''}
       </head>
       <body>
-        <div id='app'>${app || ''}</div>
+        <div id='app'>${markup || ''}</div>
 
         ${initialState
            ? inlineScript(`window.APP_STATE=${serialize(initialState)};`)


### PR DESCRIPTION
Hmm.. I actually wanted to include only this commit - https://github.com/ctrlplusb/react-universally/pull/175/commits/3b7743243b8c5313ac53d90f5bc35ca9b14e806a

It fixes a typo, where the render method passed a 'markup' variable, however it was never used (expected 'app'), so I changed it to `markup`.