### PR TITLE
Add link to manifest.json in render html template

### DIFF
--- a/src/universalMiddleware/render.js
+++ b/src/universalMiddleware/render.js
@@ -114,6 +114,7 @@ function render(args: RenderArgs) {
   return `<!DOCTYPE html>
     <html ${helmet ? helmet.htmlAttributes.toString() : ''}>
       <head>
+        <link rel="manifest" href="/manifest.json" />
         ${helmet ? helmet.title.toString() : ''}
         ${helmet ? helmet.meta.toString() : ''}
         ${helmet ? helmet.link.toString() : ''}


### PR DESCRIPTION
Add the manifest to the template, or would you prefer doing this through react-helmet?