### PR TITLE
fix the "collectCoverageFrom" config of jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
+      "shared/**/*.{js,jsx}"
     ],
     "snapshotSerializers": [
       "<rootDir>/node_modules/enzyme-to-json/serializer"


### PR DESCRIPTION
Thanks for your awesome work! It's really cooool

I am wondering whether `src/**/*.{js,jsx}` should be `shared/**/*.{js,jsx}`, or it would get result below:

```
>  jest --coverage

 PASS  shared/components/DemoApp/AsyncHomeRoute/__tests__/HomeRoute.test.js
 PASS  shared/components/DemoApp/Error404/__tests__/Error404.test.js
 PASS  shared/components/DemoApp/AsyncAboutRoute/__tests__/AboutRoute.test.js
 PASS  shared/components/DemoApp/Header/Menu/__tests__/Menu.test.js
----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |  Unknown |  Unknown |  Unknown |  Unknown |                |
----------|----------|----------|----------|----------|----------------|

```
