### PR TITLE
dev server host always 0.0.0.0, not host config

### DIFF
--- a/internal/development/hotClientServer.js
+++ b/internal/development/hotClientServer.js
@@ -34,7 +34,7 @@ class HotClientServer {
     app.use(this.webpackDevMiddleware);
     app.use(createWebpackHotMiddleware(compiler));
 
-    const listener = app.listen(port, host);
+    const listener = app.listen(port);
 
     this.listenerManager = new ListenerManager(listener, 'client');
 


### PR DESCRIPTION
This is an change additional to https://github.com/ctrlplusb/react-universally/issues/398 to help with remote development.

Now for example if I'm running my dev server and exposing it on a random IP, `12.23.34.45`, I can set `HOST` to `12.23.34.45` and assets will be referenced correctly, and the dev server will still attempt to start up binding to the correct 0.0.0.0