### PR TITLE
Add color support for stdout

### DIFF
--- a/internal/development/hotNodeServer.js
+++ b/internal/development/hotNodeServer.js
@@ -22,7 +22,7 @@ class HotNodeServer {
         });
       }
 
-      const newServer = spawn('node', [compiledEntryFile]);
+      const newServer = spawn('node', [compiledEntryFile, '--color']);
 
       log({
         title: name,


### PR DESCRIPTION
This flag enables color support of the node executable opened by spawn.

It also works to add `colors.enabled = true;` somewhere in the application, but this is the best solution 👍 