### PR TITLE
Fixed Access-Control-Allow-Origin for HMR

### DIFF
--- a/internal/development/hotClientServer.js
+++ b/internal/development/hotClientServer.js
@@ -2,7 +2,6 @@ import express from 'express';
 import createWebpackMiddleware from 'webpack-dev-middleware';
 import createWebpackHotMiddleware from 'webpack-hot-middleware';
 import ListenerManager from './listenerManager';
-import config from '../../config';
 import { log } from '../utils';
 
 class HotClientServer {
@@ -24,7 +23,7 @@ class HotClientServer {
       quiet: true,
       noInfo: true,
       headers: {
-        'Access-Control-Allow-Origin': `http://${config('host')}:${config('port')}`,
+        'Access-Control-Allow-Origin': '*',
       },
       // Ensure that the public path is taken from the compiler webpack config
       // as it will have been created as an absolute path to avoid conflicts


### PR DESCRIPTION
Currently hot reloading of changes is not working because of Access-Control-Allow-Origin header.
The issue, together with the proposed resolution, is described [here](https://github.com/gaearon/react-hot-loader/blob/master/docs/Troubleshooting.md#no-access-control-allow-origin-header-is-present-on-the-requested-resource).

This may also fix this issue: https://github.com/ctrlplusb/react-universally/issues/421

This change fixes the problem, however I'm not sure if there are some unwanted side effects with this. I'd imagine a  `Access-Control-Allow-Origin *` should not be a problem for the dev server.