### PR TITLE
Fix link to phantom page in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Feature Branch
 
-Note: This is a feature branch of `react-universally`. Please see the [`FEATURE_REDUX_OPINIONATED.md`](/docs/FEATURE_REDUX_OPINIONATED.md) for more information on this branch.
+Note: This is a feature branch of `react-universally`. 
 
 ---
 


### PR DESCRIPTION
The README has a link to the Feature page for Redux which actually doesn't exist. So, removing it to prevent confusion.