### PR TITLE
(next) Fix raf polyfill and move all `universal` polyfills in sared dir

### DIFF
--- a/client/polyfills/index.js
+++ b/client/polyfills/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import Modernizr from 'modernizr';
-import 'raf';
+import '../../shared/polyfills';
 // This is just an illustrative example.  Here you are testing the client's
 // support for the "picture" element, and if it isn't supported then you
 // load a polyfill.

--- a/internal/jest/setupFile.js
+++ b/internal/jest/setupFile.js
@@ -1,5 +1,6 @@
+/* eslint import/first: "off" */
+import '../../shared/polyfills';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import 'raf';
 
 configure({ adapter: new Adapter() });

--- a/shared/polyfills.js
+++ b/shared/polyfills.js
@@ -1,0 +1,7 @@
+/**
+ * This file contains polyfills that should be shared for all the environments,
+ * where our app runs
+ */
+import { polyfill as rafPolyfill } from 'raf';
+
+rafPolyfill();


### PR DESCRIPTION
In #510 there was added raf polyfill, but it was not applied. This PR invokes the polyfill function to fix warning from `react`.

Another one change: I've moved all the polyfills, that are shared for all environments int `shared` dir. I can move that file somewhere else. The main message is that we should not copy-paste polyfill functions throughout the project.