### PR TITLE
Adding 'Community forks and extensions' to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Now go make some changes to the `Home` component to see the tooling in action.
  - [Deploy your very own Server Side Rendering React App in 5 easy steps](/internal/docs/DEPLOY_TO_NOW.md)
  - [Changelog](/CHANGELOG.md)
 
+## Who's using it and where?
+
+You can see who is using it and how in [the comments here](https://github.com/ctrlplusb/react-universally/issues/437). Feel free to add to that telling us how you are using it, we'd love to hear from you.
+
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This starter kit contains all the build tooling and configuration you need to ki
   - 🌍 Server Side Rendering.
   - 😎 Progressive Web Application ready, with offline support, via a Service Worker.
   - 🐘 Long term browser caching of assets with automated cache invalidation.
-  - 📦 All source is bundled using Webpack v2.
+  - 📦 All source is bundled using Webpack v3.
   - 🚀 Full ES2017+ support - use the exact same JS syntax across the entire project. No more folder context switching! We also only use syntax that is stage-3 or later in the TC39 process.
   - 🔧 Centralised application configuration with helpers to avoid boilerplate in your code. Also has support for environment specific configuration files.
   - 🔥 Extreme live development - hot reloading of ALL changes to client/server source, with auto development server restarts when your application configuration changes.  All this with a high level of error tolerance and verbose logging to the console.

--- a/internal/docs/FEATURE_BRANCHES.md
+++ b/internal/docs/FEATURE_BRANCHES.md
@@ -12,7 +12,7 @@ Below are a list of extensions to this repository, in the form of branches.  Eac
  - [`apollo`](https://github.com/ctrlplusb/react-universally/tree/feature/apollo) - Adds the Apollo Stack (i.e. Graphql).
  - [`mobx`](https://github.com/andreyluiz/react-universally/tree/feature/mobx) - Adds MobX as a state management library.
  - [`postcss-sass`](https://github.com/ctrlplusb/react-universally/tree/feature/postcss-sass) - Adds PostCSS and SASS.
- - [`redux-opinionated`](https://github.com/ctrlplusb/react-universally/tree/feature/redux-opinionated) - Adds an opinionated Redux implementation, using `redux-thunk` and `react-jobs` to support data loading across the client/server.  It also merges in the `flow` feature branch.
+ - [`redux-opinionated`](https://github.com/ctrlplusb/react-universally/tree/feature/redux-opinionated) - Adds an opinionated Redux implementation, using `redux-thunk` and `react-jobs` to support data loading across the client/server.
 
 If you would like to add a new feature branch log an issue describing your chosen technology and we can come up with a plan together. :)
 

--- a/internal/docs/PKG_SCRIPTS.md
+++ b/internal/docs/PKG_SCRIPTS.md
@@ -9,11 +9,11 @@
 
 ## `npm run analyze:client`
 
-Creates an 'webpack-bundle-analyze' session against the production build of the client bundle.
+Creates an `webpack-bundle-analyze` session against the production build of the client bundle.
 
 ## `npm run analyze:server`
 
-Creates an 'webpack-bundle-analyze' session against the production build of the server bundle.
+Creates an `webpack-bundle-analyze` session against the production build of the server bundle.
 
 ## `npm run build`
 
@@ -43,10 +43,10 @@ Executes `eslint` against the project. Alternatively you could look to install t
 
 Executes the server.  It expects you to have already built the bundles using the `npm run build` command.
 
-## `npm run test`
+## `npm run test`
 
 Runs the `jest` tests.
 
-## `npm run test:coverage`
+## `npm run test:coverage`
 
 Runs the `jest` tests and generates a coverage report. I recommend you look at [codecov.io](https://codecov.io) to host your coverage reports.

--- a/internal/docs/PROJECT_OVERVIEW.md
+++ b/internal/docs/PROJECT_OVERVIEW.md
@@ -9,7 +9,7 @@
 
 Below is a general overview of the project.
 
-## TOC
+## ToC
 
  - [Bundled by Webpack](#bundled-by-webpack)
  - [Transpiled by Babel](#transpiled-by-babel)

--- a/internal/docs/PROJECT_OVERVIEW.md
+++ b/internal/docs/PROJECT_OVERVIEW.md
@@ -18,7 +18,7 @@ Below is a general overview of the project.
 
 ## Bundled by Webpack
 
-This starter uses Webpack 2 to produce bundles for both the client and the server. The `internal/webpack/configFactory.js` is used to generate the respective Webpack configuration for all our bundles. The factory is heavily commented to help you understand what is going on within the Webpack configuration.
+This starter uses Webpack 3 to produce bundles for both the client and the server. The `internal/webpack/configFactory.js` is used to generate the respective Webpack configuration for all our bundles. The factory is heavily commented to help you understand what is going on within the Webpack configuration.
 
 > Note: Given that we are bundling our server code I have included the `source-map-support` module to ensure that we still get nice stack traces when executing our code.
 


### PR DESCRIPTION
This adds a section for community forks in the README, addressing #504, and sets us up for reducing feature branch maintainence load.