### PR TITLE
babel-preset-env usage adjustment

### DIFF
--- a/internal/webpack/configFactory.js
+++ b/internal/webpack/configFactory.js
@@ -55,9 +55,9 @@ export default function webpackConfigFactory(buildOptions) {
   const bundleConfig =
     isServer || isClient
       ? // This is either our "server" or "client" bundle.
-      config(['bundles', target])
+        config(['bundles', target])
       : // Otherwise it must be an additional node bundle.
-      config(['additionalNodeBundles', target]);
+        config(['additionalNodeBundles', target]);
 
   if (!bundleConfig) {
     throw new Error('No bundle configuration exists for target:', target);
@@ -80,9 +80,9 @@ export default function webpackConfigFactory(buildOptions) {
         // Required to support hot reloading of our client.
         ifDevClient(
           () =>
-            `webpack-hot-middleware/client?reload=true&path=http://${config('host')}:${config(
-              'clientDevServerPort',
-            )}/__webpack_hmr`,
+            `webpack-hot-middleware/client?reload=true&path=http://${config(
+              'host',
+            )}:${config('clientDevServerPort')}/__webpack_hmr`,
         ),
 
         // The source entry file for the bundle.
@@ -127,9 +127,9 @@ export default function webpackConfigFactory(buildOptions) {
 
     target: isClient
       ? // Only our client bundle will target the web as a runtime.
-      'web'
+        'web'
       : // Any other bundle must be targetting node as a runtime.
-      'node',
+        'node',
 
     // Ensure that webpack polyfills the following node features for use
     // within any bundles that are targetting node as a runtime. This will be
@@ -381,11 +381,11 @@ export default function webpackConfigFactory(buildOptions) {
                   // ES201X code into ES5, safe for browsers.  We exclude module
                   // transilation as webpack takes care of this for us, doing
                   // tree shaking in the process.
-                  ifClient(['env', { es2015: { modules: false } }]),
+                  ifClient(['env', { modules: false }]),
                   // For a node bundle we use the specific target against
                   // babel-preset-env so that only the unsupported features of
                   // our target node version gets transpiled.
-                  ifNode(['env', { targets: { node: true } }]),
+                  ifNode(['env', { targets: { node: true }, modules: false }]),
                 ].filter(x => x != null),
 
                 plugins: [
@@ -452,7 +452,9 @@ export default function webpackConfigFactory(buildOptions) {
               // details on what loader is being implemented.
               loader: 'happypack/loader?id=happypack-javascript',
               include: removeNil([
-                ...bundleConfig.srcPaths.map(srcPath => path.resolve(appRootDir.get(), srcPath)),
+                ...bundleConfig.srcPaths.map(srcPath =>
+                  path.resolve(appRootDir.get(), srcPath),
+                ),
                 ifProdClient(path.resolve(appRootDir.get(), 'src/html')),
               ]),
             },
@@ -520,12 +522,12 @@ export default function webpackConfigFactory(buildOptions) {
                 // paths used on the client.
                 publicPath: isDev
                   ? // When running in dev mode the client bundle runs on a
-                  // seperate port so we need to put an absolute path here.
-              `http://${config('host')}:${config('clientDevServerPort')}${config(
-                'bundles.client.webPath',
-              )}`
+                    // seperate port so we need to put an absolute path here.
+                    `http://${config('host')}:${config(
+                      'clientDevServerPort',
+                    )}${config('bundles.client.webPath')}`
                   : // Otherwise we just use the configured web path for the client.
-                  config('bundles.client.webPath'),
+                    config('bundles.client.webPath'),
                 // We only emit files when building a web bundle, for the server
                 // bundle we only care about the file loader being able to create
                 // the correct asset URLs.


### PR DESCRIPTION
This switches how `babel-preset-env` is used. Currently we look like 

```
['env', { 
     es2015: { modules: false }
}]
```

The es2015 portion was dropped a while back if I remember right. Nothing in the babel docs mentions using it any more. Figured we'd reflect the documentation.

As a side note, running the preset w/ debug: true appears to produce the exact same output 😕 