### PR TITLE
Fix webpack v4 issue where webpackHotUpdate is not defined on hard reload

### DIFF
--- a/internal/webpack/configFactory.js
+++ b/internal/webpack/configFactory.js
@@ -320,7 +320,12 @@ export default function webpackConfigFactory(buildOptions) {
       ifDev(() => new webpack.NoEmitOnErrorsPlugin()),
 
       // We need this plugin to enable hot reloading of our client.
-      ifDevClient(() => new webpack.HotModuleReplacementPlugin()),
+      ifDevClient(
+        () =>
+          new webpack.HotModuleReplacementPlugin({
+            multiStep: true,
+          }),
+      ),
 
       // For the production build of the client we need to extract the CSS into
       // CSS files.


### PR DESCRIPTION
See [here](https://github.com/webpack/webpack/issues/6693) for related issue thread on [webpack](https://github.com/webpack/webpack).

TLDR:

- Run `npm run develop`
- It builds & opens successfully
- Change something to emit update
- Webpack rebuilds successfully
- Update whole page with hard reload
- Receive `webpackHotUpdate is not defined` error in console

Seems that in webpack v3, ` new webpack.HotModuleReplacementPlugin(),` works fine, but in v4 we need to add `{ multiStep: true }`