### PR TITLE
Add HardSourceWebpackPlugin for better build times

### DIFF
--- a/internal/webpack/configFactory.js
+++ b/internal/webpack/configFactory.js
@@ -3,6 +3,7 @@ import AssetsPlugin from 'assets-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import UglifyJsPlugin from 'uglifyjs-webpack-plugin';
 import nodeExternals from 'webpack-node-externals';
+import HardSourceWebpackPlugin from 'hard-source-webpack-plugin';
 import path from 'path';
 import webpack from 'webpack';
 
@@ -318,6 +319,9 @@ export default function webpackConfigFactory(buildOptions) {
       // We don't want webpack errors to occur during development as it will
       // kill our dev servers.
       ifDev(() => new webpack.NoEmitOnErrorsPlugin()),
+
+      // Cache loaders output improving build times
+      ifDev(() => new HardSourceWebpackPlugin()),
 
       // We need this plugin to enable hot reloading of our client.
       ifDevClient(

--- a/package-lock.json
+++ b/package-lock.json
@@ -6024,6 +6024,22 @@
         "har-schema": "2.0.0"
       }
     },
+    "hard-source-webpack-plugin": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.6.4.tgz",
+      "integrity": "sha512-+JrX43xkJ2aLnrQcDXhYEuCXgC+WfMNwJ1CcNqOLzR+miz/gNUUA86Q3fUOph6dFQ42AgArNU623xyLJGzZ3ag==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "node-object-hash": "1.3.0",
+        "rimraf": "2.6.2",
+        "tapable": "1.0.0",
+        "webpack-core": "0.6.9",
+        "webpack-sources": "1.1.0",
+        "write-json-file": "2.3.0"
+      }
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -9475,6 +9491,12 @@
         "shellwords": "0.1.1",
         "which": "1.3.0"
       }
+    },
+    "node-object-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-1.3.0.tgz",
+      "integrity": "sha512-/IHFGoMJWIAcFbrI3KYx6TUmHdBXRZXACAVbkHzYB39JZzoVqgme7wcMnhrOwCvrO8HfIipFTBhELJFMhiw1mg==",
+      "dev": true
     },
     "nomnom": {
       "version": "1.6.2",
@@ -14133,6 +14155,33 @@
         }
       }
     },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "0.1.8",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-list-map": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+          "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
     "webpack-dev-middleware": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz",
@@ -14308,6 +14357,43 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "signal-exit": "3.0.2"
+      }
+    },
+    "write-json-file": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+      "dev": true,
+      "requires": {
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.2.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
       }
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "file-loader": "1.1.11",
     "glob": "7.1.2",
     "happypack": "5.0.0-beta.1",
+    "hard-source-webpack-plugin": "0.6.4",
     "html-webpack-plugin": "3.0.6",
     "husky": "0.14.3",
     "istanbul-api": "1.3.1",


### PR DESCRIPTION
Easy 3x faster build times (even more on slow machines, I got 5x improvements at the default boilerplate and 16x in a large project of mine)

Some numbers here: https://github.com/mzgoddard/hard-source-webpack-plugin/issues/251

Note: cant be used for production builds right now cause of an [issue](https://github.com/mzgoddard/hard-source-webpack-plugin/issues/289) with OfflinePlugin used for the Service Worker in this project